### PR TITLE
Prepare whawty.auth for auxiliary data

### DIFF
--- a/doc/SCHEMA.md
+++ b/doc/SCHEMA.md
@@ -20,6 +20,12 @@ database but should only be used by management interfaces of a whawty.auth agent
 You may want to take a look at [whawty.groups](https://github.com/whawty/groups)
 if you need an authorisation database.
 
+The directory may also contains a `.tmp` directory: agents that update
+the whawty.auth base must perform file modifications atomically by
+writing new files, with a random name, in that directory, then
+atomically moving them to their final destination.  As such, `.tmp`
+should be backed by the same filesystem as the whawty.auth base.
+
 The directory must not contain any other files. A valid whawty.auth base
 directory contains at least one admin file which uses a supported hashing
 format.

--- a/store/store.go
+++ b/store/store.go
@@ -59,6 +59,7 @@ var (
 const (
 	adminExt string = ".admin"
 	userExt  string = ".user"
+	tmpDir   string = ".tmp"
 )
 
 func init() {
@@ -117,7 +118,7 @@ func openDir(path string) (*os.File, error) {
 // getTempFile provides a new, empty file in the base's .tmp directory,
 //  suitable for atomic file updates (by create/write/rename)
 func (dir *Dir) getTempFile() (tmp *os.File, err error) {
-	tmpDir := path.Join(dir.BaseDir, ".tmp")
+	tmpDir := path.Join(dir.BaseDir, tmpDir)
 	err = os.MkdirAll(tmpDir, 0700)
 	if err != nil {
 		return nil, err
@@ -211,7 +212,7 @@ func listSupportedUsers(dir *os.File, list UserList) error {
 
 		for _, name := range names {
 			// Skip the '.tmp' directory
-			if name == ".tmp" {
+			if name == tmpDir {
 				continue
 			}
 

--- a/store/store.go
+++ b/store/store.go
@@ -42,6 +42,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -111,6 +112,23 @@ func openDir(path string) (*os.File, error) {
 	}
 
 	return dir, nil
+}
+
+// getTempFile provides a new, empty file in the base's .tmp directory,
+//  suitable for atomic file updates (by create/write/rename)
+func (dir *Dir) getTempFile() (tmp *os.File, err error) {
+	tmpDir := path.Join(dir.BaseDir, ".tmp")
+	err = os.MkdirAll(tmpDir, 0700)
+	if err != nil {
+		return nil, err
+	}
+
+	tmp, err = ioutil.TempFile(tmpDir, "")
+	if err != nil {
+		return tmp, err
+	}
+
+	return tmp, nil
 }
 
 func isDirEmpty(dir *os.File) bool {

--- a/store/store.go
+++ b/store/store.go
@@ -210,6 +210,11 @@ func listSupportedUsers(dir *os.File, list UserList) error {
 		}
 
 		for _, name := range names {
+			// Skip the '.tmp' directory
+			if name == ".tmp" {
+				continue
+			}
+
 			valid, user, isAdmin, err := checkUserFile(name)
 			if err != nil {
 				return err

--- a/store/userhash.go
+++ b/store/userhash.go
@@ -134,7 +134,7 @@ func (u *UserHash) getFilename(isAdmin bool) string {
 	return filename + userExt
 }
 
-func (u *UserHash) writeHashStr(password string, isAdmin bool, flags int) error {
+func (u *UserHash) writeHashStr(password string, isAdmin bool, mayCreate bool) error {
 	formatID := u.store.DefaultFormat
 
 	var hashStr string
@@ -149,14 +149,49 @@ func (u *UserHash) writeHashStr(password string, isAdmin bool, flags int) error 
 		return fmt.Errorf("whawty.auth.store: default hash file fromat ID '%s' is not supported", formatID)
 	}
 
+	// Set the flags based on whether we expect to create the file
+	// The file is opened read-only, since we write to a tmp file and atomically move it in place.
+	flags := os.O_RDONLY | os.O_EXCL
+	if mayCreate {
+		flags = flags | os.O_CREATE
+	}
+
 	file, err := os.OpenFile(u.getFilename(isAdmin), flags, 0600)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
 
-	_, err = io.WriteString(file, fmt.Sprintf("%s:%d:%s\n", formatID, time.Now().Unix(), hashStr)) // TODO: retry if write was short??
-	return err
+	tmp, err := u.store.getTempFile()
+	if err != nil {
+		return err
+	}
+	defer tmp.Close()
+	defer os.Remove(tmp.Name()) // Ensure that the file gets removed in case of failure
+
+	// Write the new password hash
+	_, err = io.WriteString(tmp, fmt.Sprintf("%s:%d:%s\n", formatID, time.Now().Unix(), hashStr)) // TODO: retry if write was short??
+	if err != nil {
+		return err
+	}
+
+	// Create a reader for the original file
+	reader := bufio.NewReader(file)
+
+	// Skip the first line
+	_, err = reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return err
+	}
+
+	// Write the rest of the old file to the new one
+	_, err = reader.WriteTo(tmp)
+	if err != nil {
+		return err
+	}
+
+	// Atomically move the new file in place
+	return os.Rename(tmp.Name(), file.Name())
 }
 
 // Add creates the hash file. It is an error if the user already exists.
@@ -167,7 +202,7 @@ func (u *UserHash) Add(password string, isAdmin bool) error {
 	} else if exists {
 		return fmt.Errorf("whawty.auth.store: user '%s' already exists", u.user)
 	}
-	return u.writeHashStr(password, isAdmin, os.O_WRONLY|os.O_CREATE|os.O_EXCL)
+	return u.writeHashStr(password, isAdmin, true)
 }
 
 // Update changes the password for user.
@@ -183,7 +218,7 @@ func (u *UserHash) Update(password string) error {
 		return fmt.Errorf("whawty.auth.store: won't overwrite unsupported hash format")
 	}
 
-	return u.writeHashStr(password, isAdmin, os.O_WRONLY|os.O_TRUNC)
+	return u.writeHashStr(password, isAdmin, false)
 }
 
 // SetAdmin changes the admin status of user.

--- a/store/userhash.go
+++ b/store/userhash.go
@@ -32,9 +32,9 @@
 package store
 
 import (
+	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -68,8 +68,10 @@ func readHashStr(filename string) (string, time.Time, string, error) {
 	}
 	defer file.Close()
 
-	data, err := ioutil.ReadAll(file)
-	if err != nil {
+	reader := bufio.NewReader(file)
+
+	data, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
 		return "", time.Unix(0, 0), "", err
 	}
 


### PR DESCRIPTION
- [x] Make `userhash` only read and parse the first line of user files.
- [x] Make `userhash` preserve the auxiliary data when updating password hashes.
- [x] Make base updates atomic (required, since several agents may update the auxiliary data)
  - Document (in `doc/SCHEMA`) a path for temporary files and a mechanism for atomic updates.
  - Add a `getTempFile` helper in `store`
  - Update `writeUserHash` accordingly, replace its `flag` parameter by `mayCreate`