### PR TITLE
improved error message for config loading

### DIFF
--- a/store/config.go
+++ b/store/config.go
@@ -68,7 +68,7 @@ func readConfig(configfile string) (*config, error) {
 
 	jsondata, err := ioutil.ReadAll(file)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error opening store config file: %v", err)
 	}
 
 	c := &config{}


### PR DESCRIPTION
was:
```
Error opening whawty store: read ./store: is a directory
```

is now:
```
Error opening whawty store: Error opening store config file: read ./store: is a directory
```