### PR TITLE
.agignore: Ignore all bootstrap, jquery and zxcvbn

### DIFF
--- a/.agignore
+++ b/.agignore
@@ -1,3 +1,3 @@
-app/html/bootstrap/js/bootstrap.min.js
-app/html/bootstrap/css/bootstrap.min.css
-app/html/jquery/jquery.min.js
+app/html/bootstrap
+app/html/jquery
+app/html/js/zxcvbn.js


### PR DESCRIPTION
Getting the entire wordlist from zxcvbn when grepping the source
is pretty annoying.